### PR TITLE
Add syntax highlighting for interpreter directives

### DIFF
--- a/syntax/tengo.vim
+++ b/syntax/tengo.vim
@@ -13,6 +13,10 @@ syn case match
 syn region      FoldingBrace        start="{" end="}" transparent fold
 syn region      FoldingParen        start='(' end=')' transparent fold
 
+" Interpreter directive
+syn match       HashBang            "\%1l^#!.*"
+hi def link     HashBang            PreProc
+
 " Comments
 syn region      CommentBlock        start="/\*" end="\*/"
 syn region      CommentBlock        start="//" end="$"


### PR DESCRIPTION
Tengo CLI allows users to directly execute Tengo source files if they are executable and have the interpreter directive (hasbang/shebang) such as `#!/usr/bin/tengo` defined on the first line. I therefore suggest adding syntax highlighting for this to the syntax file.