### PR TITLE
Add support for backticks

### DIFF
--- a/syntax/tengo.vim
+++ b/syntax/tengo.vim
@@ -21,6 +21,7 @@ hi def link     CommentBlock        Comment
 
 " Interpreted strings
 syn region      InterpString        start=+"+ skip=+\\\\\|\\"+ end=+"+
+syn region      InterpString        start=+`+ skip=+\\\\\|\\"+ end=+`+
 hi def link     InterpString        string
 
 " Raw strings


### PR DESCRIPTION
According to [Tengo documentation](https://github.com/d5/tengo/blob/master/docs/tutorial.md#values-and-value-types), string values can be enclosed in either double quotes `"` or backticks `` ` ``. I suggest adding backticks to syntax highlighting for strings.